### PR TITLE
Add dual-instance Aspire setup with dev portal & Scalar docs

### DIFF
--- a/ArvidsonFoto.AppHost/AppHost.cs
+++ b/ArvidsonFoto.AppHost/AppHost.cs
@@ -3,9 +3,17 @@
 // ArvidsonFoto already uses in-memory database in development (appsettings.Development.json)
 // No need for SQL Server container when UseInMemoryDatabase is true
 
-// Add the main ArvidsonFoto web application
-var arvidsonFoto = builder.AddProject<Projects.ArvidsonFoto>("arvidsonfoto")
+// Add the main ArvidsonFoto web application (public-facing website)
+var arvidsonFoto = builder
+    .AddProject<Projects.ArvidsonFoto>("arvidsonfoto", launchProfileName: "ArvidsonFoto")
     .WithExternalHttpEndpoints();
+
+// Add a second instance for API documentation and Admin panel
+// Uses the 'arvidsonfoto-dev-portal' launch profile from launchSettings.json
+// which defines https://localhost:5011 and launchUrl /dev
+var arvidsonFotoDevPortal = builder
+    .AddProject<Projects.ArvidsonFoto>("arvidsonfoto-dev-and-api-portal", launchProfileName: "ArvidsonFoto-dev-portal")
+    .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development");
 
 // Optionally add the LogReader application
 // var logReader = builder.AddProject<Projects.ArvidsonFoto_LogReader>("logreader")

--- a/ArvidsonFoto.AppHost/ArvidsonFoto.AppHost.csproj
+++ b/ArvidsonFoto.AppHost/ArvidsonFoto.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
 
   <ItemGroup>
     <ProjectReference Include="..\ArvidsonFoto\ArvidsonFoto.csproj" />

--- a/ArvidsonFoto/ArvidsonFoto.csproj
+++ b/ArvidsonFoto/ArvidsonFoto.csproj
@@ -39,14 +39,18 @@
     </PackageReference>
     <PackageReference Include="Serilog" Version="4.3.1-dev-02385" /> <!-- Används för loggning -->
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" /> <!-- Används för loggning till fil -->
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" /> <!-- Används för loggning till konsol i Development -->
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.477" /> <!-- För CSS/JS minifiering och bundling -->
     <PackageReference Include="LigerShark.WebOptimizer.Sass" Version="3.0.143" /> <!-- För SCSS kompilering -->
     <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.29.1" /> <!-- JavaScript engine för SCSS kompilering -->
     <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.24.1" /> <!-- DI för JS engine -->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" /> <!-- OpenAPI support -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0" /> <!-- OpenAPI models -->
+    <PackageReference Include="Scalar.AspNetCore" Version="1.2.68" /> <!-- Scalar UI för OpenAPI dokumentation -->
   </ItemGroup>
 
   <ItemGroup Label="Folders">
+    <Folder Include="Core\OpenApi\" />
     <Folder Include="logs\" /> <!-- Mapp dit jag styrt att Serilog, ska lägga sina .log-filer -->
   </ItemGroup>
 

--- a/ArvidsonFoto/Controllers/ApiControllers/CategoryApiController.cs
+++ b/ArvidsonFoto/Controllers/ApiControllers/CategoryApiController.cs
@@ -17,6 +17,7 @@ namespace ArvidsonFoto.Controllers.ApiControllers;
 [ApiController]
 [Route("api/category")]
 [Route("api/kategori")]
+[Tags("Categories")]
 public class CategoryApiController(ILogger<CategoryApiController> logger,
     IApiCategoryService apiCategoryService) : ControllerBase
 {

--- a/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
+++ b/ArvidsonFoto/Controllers/ApiControllers/ImageApiController.cs
@@ -17,6 +17,7 @@ namespace ArvidsonFoto.Controllers.ApiControllers;
 [ApiController]
 [Route("api/image")]
 [Route("api/bild")]
+[Tags("Images")]
 public class ImageApiController(ILogger<ImageApiController> logger,
     IApiImageService imageService,
     ArvidsonFotoCoreDbContext entityContext, //TODO: Bör bygga bort denna och enbart använda IApiImageService

--- a/ArvidsonFoto/Controllers/DevController.cs
+++ b/ArvidsonFoto/Controllers/DevController.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ArvidsonFoto.Controllers;
+
+/// <summary>
+/// Controller for development/admin landing page
+/// </summary>
+public class DevController : Controller
+{
+    /// <summary>
+    /// Landing page that shows links to API documentation and Admin panel
+    /// </summary>
+    [Route("/dev")]
+    [Route("/admin")]
+    public IActionResult Index()
+    {
+        // Only accessible in Development mode
+        if (!HttpContext.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
+        {
+            return NotFound();
+        }
+
+        return View();
+    }
+}

--- a/ArvidsonFoto/Properties/launchSettings.json
+++ b/ArvidsonFoto/Properties/launchSettings.json
@@ -17,6 +17,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "ArvidsonFoto-dev-portal": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "/dev",
+      "applicationUrl": "https://localhost:5011",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/ArvidsonFoto/Views/Dev/Index.cshtml
+++ b/ArvidsonFoto/Views/Dev/Index.cshtml
@@ -1,0 +1,129 @@
+﻿@{
+    ViewData["Title"] = "Development & Admin Portal";
+}
+
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="text-center mb-5">
+                <h1 class="display-4">
+                    <i class="bi bi-tools"></i> ArvidsonFoto
+                </h1>
+                <h2>Development & Admin Portal</h2>
+                <p class="text-muted">Quick access to development tools and admin features</p>
+            </div>
+
+            <!-- API Documentation Card -->
+            <div class="card mb-4 shadow hover-shadow-lg">
+                <div class="card-header bg-primary text-white">
+                    <h3 class="mb-0">
+                        <i class="bi bi-file-code"></i> API Documentation
+                    </h3>
+                </div>
+                <div class="card-body">
+                    <p class="card-text">
+                        Interactive API documentation powered by Scalar. Explore all endpoints, test requests, 
+                        and view response schemas.
+                    </p>
+                    <div class="d-grid gap-2 d-md-flex justify-content-md-start">
+                        <a href="/scalar/v1" class="btn btn-primary btn-lg" target="_blank">
+                            <i class="bi bi-rocket-takeoff"></i> Open Scalar API Docs
+                        </a>
+                        <a href="/openapi/v1.json" class="btn btn-outline-secondary" target="_blank">
+                            <i class="bi bi-file-earmark-code"></i> View OpenAPI JSON
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Admin Panel Card -->
+            <div class="card mb-4 shadow hover-shadow-lg">
+                <div class="card-header bg-success text-white">
+                    <h3 class="mb-0">
+                        <i class="bi bi-shield-lock"></i> Admin Panel
+                    </h3>
+                </div>
+                <div class="card-body">
+                    <p class="card-text">
+                        Manage images, categories, and view statistics. 
+                        <strong>Note:</strong> Authentication required.
+                    </p>
+                    <div class="d-grid gap-2 d-md-flex justify-content-md-start">
+                        <a href="/UploadAdmin" class="btn btn-success btn-lg">
+                            <i class="bi bi-gear"></i> Open Admin Panel
+                        </a>
+                        <a href="/UploadAdmin/RedigeraBilder" class="btn btn-outline-success">
+                            <i class="bi bi-pencil-square"></i> Edit Images
+                        </a>
+                        <a href="/UploadAdmin/HanteraGB" class="btn btn-outline-success">
+                            <i class="bi bi-book"></i> Manage Guestbook
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Database & Tools Card -->
+            <div class="card mb-4 shadow hover-shadow-lg">
+                <div class="card-header bg-info text-white">
+                    <h3 class="mb-0">
+                        <i class="bi bi-database"></i> Development Tools
+                    </h3>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <h5><i class="bi bi-check-circle"></i> Environment</h5>
+                            <ul class="list-unstyled">
+                                <li>✅ In-Memory Database</li>
+                                <li>✅ Development Mode</li>
+                                <li>✅ Console Logging</li>
+                                <li>✅ CORS Enabled</li>
+                            </ul>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <h5><i class="bi bi-link-45deg"></i> Quick Links</h5>
+                            <ul class="list-unstyled">
+                                <li><a href="/"><i class="bi bi-house"></i> Main Website</a></li>
+                                <li><a href="/Info/Sidkarta"><i class="bi bi-diagram-3"></i> Sitemap</a></li>
+                                <li><a href="/Identity/Account/Login"><i class="bi bi-box-arrow-in-right"></i> Login</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Aspire Dashboard Info -->
+            <div class="alert alert-light border" role="alert">
+                <h5 class="alert-heading"><i class="bi bi-info-circle"></i> Running via .NET Aspire</h5>
+                <p class="mb-0">
+                    This portal is accessible through the Aspire AppHost. 
+                    Check the Aspire dashboard for more monitoring and debugging tools.
+                </p>
+            </div>
+
+            <div class="text-center mt-4">
+                <p class="text-muted">
+                    <small>
+                        <i class="bi bi-exclamation-triangle"></i> 
+                        This page is only accessible in Development mode
+                    </small>
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .hover-shadow-lg:hover {
+        transform: translateY(-5px);
+        transition: all 0.3s ease;
+    }
+    
+    .card-header h3 {
+        font-size: 1.5rem;
+    }
+    
+    .btn-lg i {
+        margin-right: 0.5rem;
+    }
+</style>


### PR DESCRIPTION
- AppHost now launches main site and separate dev/admin portal
- Integrate Scalar UI for interactive OpenAPI docs in dev mode
- Add DevController and landing page for admin/dev tools
- Enable Serilog console logging in Development environment
- Update README with dual-instance usage, ports, and workflows
- Add NuGet packages: Scalar.AspNetCore, Microsoft.OpenApi, Serilog.Sinks.Console
- Tag API controllers for improved OpenAPI grouping