### PR TITLE
Version bump to v3.10.5

### DIFF
--- a/ArvidsonFoto/ArvidsonFoto.csproj
+++ b/ArvidsonFoto/ArvidsonFoto.csproj
@@ -15,7 +15,7 @@
     <RootNamespace>ArvidsonFoto</RootNamespace>
     <AssemblyName>ArvidsonFoto</AssemblyName>
     <IsPackable>false</IsPackable>
-    <Version>3.10.2</Version>
+    <Version>3.10.5</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="DeterministicBuild">

--- a/ArvidsonFoto/Views/Shared/_Layout.cshtml
+++ b/ArvidsonFoto/Views/Shared/_Layout.cshtml
@@ -3,12 +3,14 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="ArvidsonFoto-version" content="Build: v3.10.4 - Date: 2025-12-15 - Time: 23:10 - Tag: https://github.com/pownas/ArvidsonFoto-MVC-NET-web/releases/tag/v3.10.4" />
+    <meta name="ArvidsonFoto-version" content="Build: v3.10.5 - Date: 2025-12-29 - Time: 23:30 - Tag: https://github.com/pownas/ArvidsonFoto-MVC-NET-web/releases/tag/v3.10.5" />
     <partial name="_MetaData" />
     @await RenderSectionAsync("MetaData", required: false)
     <title>@ViewData["Title"] - ArvidsonFoto.se</title>
     <base href="~/" />
     <link rel="stylesheet" href="css/site.min.css" /> @*<!-- Se info i "wwwroot/css/site.scss" för alla CSS-imports... -->*@
+    @* Blazor component styles *@
+    <link href="_content/Microsoft.AspNetCore.Components.Web/css/blazor-error-ui.css" rel="stylesheet" />
 </head>
 <body>
     <header>
@@ -31,5 +33,8 @@
     <script src="js/categoryTooltip.js"></script> @*<!-- Category tooltip with image preview -->*@
     <script src="js/site.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
+    
+    @* Blazor Server SignalR script - required for interactive components *@
+    <script src="_framework/blazor.server.js"></script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-﻿![Last commit](https://img.shields.io/github/last-commit/pownas/ArvidsonFoto-MVC-NET8?style=flat-square&cacheSeconds=86400)
+﻿![Last commit](https://img.shields.io/github/last-commit/pownas/ArvidsonFoto-MVC-NET-web?style=flat-square&cacheSeconds=86400)
 
 # ArvidsonFoto-MVC .NET web
-Ombyggnation av ArvidsonFoto med MVC och .NET (uppgraderad från .NET5 till .NET6 till .NET8 till .NET9 till .NET10... osv. till senaste .NET)
+Ombyggnation av ArvidsonFoto med MVC och .NET (uppgraderad från .NET5 till .NET6 till .NET7 till .NET8 till .NET9 till .NET10... osv. till senaste .NET)
   
   
 ## Instruktion för att starta webbsidan lokalt


### PR DESCRIPTION
This pull request updates the project version to 3.10.5 and adds support for Blazor interactive components by updating the layout and including necessary styles and scripts. It also corrects project metadata in the README and layout files.

**Blazor integration:**
* Added Blazor component styles by including a link to `blazor-error-ui.css` in `_Layout.cshtml`.
* Included the Blazor Server SignalR script (`blazor.server.js`) in `_Layout.cshtml` to enable interactive components.

**Version and metadata updates:**
* Updated the project version to `3.10.5` in `ArvidsonFoto.csproj`.
* Updated the build version, date, time, and release tag in the meta tag in `_Layout.cshtml`.
* Fixed the GitHub repository reference and updated the .NET upgrade path in `README.md`.