### PR TITLE
v3.10.6 - version bump

### DIFF
--- a/ArvidsonFoto/ArvidsonFoto.csproj
+++ b/ArvidsonFoto/ArvidsonFoto.csproj
@@ -15,7 +15,7 @@
     <RootNamespace>ArvidsonFoto</RootNamespace>
     <AssemblyName>ArvidsonFoto</AssemblyName>
     <IsPackable>false</IsPackable>
-    <Version>3.10.5</Version>
+    <Version>3.10.6</Version>
   </PropertyGroup>
 
   <PropertyGroup Label="DeterministicBuild">

--- a/ArvidsonFoto/Views/Shared/_Layout.cshtml
+++ b/ArvidsonFoto/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="ArvidsonFoto-version" content="Build: v3.10.5 - Date: 2025-12-29 - Time: 23:30 - Tag: https://github.com/pownas/ArvidsonFoto-MVC-NET-web/releases/tag/v3.10.5" />
+    <meta name="ArvidsonFoto-version" content="Build: v3.10.6 - Date: 2025-12-30 - Time: 21:40 - Tag: https://github.com/pownas/ArvidsonFoto-MVC-NET-web/releases/tag/v3.10.6" />
     <partial name="_MetaData" />
     @await RenderSectionAsync("MetaData", required: false)
     <title>@ViewData["Title"] - ArvidsonFoto.se</title>


### PR DESCRIPTION
This pull request updates the application version from 3.10.5 to 3.10.6 throughout the project. The main changes are:

Version bump:

* Updated the version number in the project file `ArvidsonFoto.csproj` from 3.10.5 to 3.10.6.

Meta/version information:

* Updated the version, build date, time, and release tag in the `<meta name="ArvidsonFoto-version">` tag in the shared layout file `_Layout.cshtml` to reflect version 3.10.6.